### PR TITLE
media-libs/openimageio: Fix AVX-512 round function

### DIFF
--- a/media-libs/openimageio/files/fix_avx512_round.patch
+++ b/media-libs/openimageio/files/fix_avx512_round.patch
@@ -1,0 +1,12 @@
+https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4119
+--- a/src/include/OpenImageIO/simd.h
++++ b/src/include/OpenImageIO/simd.h
+@@ -10180,7 +10180,7 @@ OIIO_FORCEINLINE vfloat16 floor (const vfloat16& a)
+ OIIO_FORCEINLINE vfloat16 round (const vfloat16& a)
+ {
+ #if OIIO_SIMD_AVX >= 512
+-    return _mm512_roundscale_ps (a, (1<<4) | 3); // scale=1, round to nearest smaller mag int
++    return _mm512_roundscale_ps (a, (_MM_FROUND_TO_NEAREST_INT |_MM_FROUND_NO_EXC));
+ #else
+     return vfloat16(round(a.lo()), round(a.hi()));
+ #endif

--- a/media-libs/openimageio/openimageio-2.5.5.0-r1.ebuild
+++ b/media-libs/openimageio/openimageio-2.5.5.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -105,6 +105,7 @@ DOCS=(
 
 PATCHES="
 	"${FILESDIR}/fix_simd_test.patch"
+	"${FILESDIR}/fix_avx512_round.patch"
 "
 
 pkg_setup() {


### PR DESCRIPTION
See also: https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4119